### PR TITLE
Add zprobe.calibration_safety_margin

### DIFF
--- a/src/config.default
+++ b/src/config.default
@@ -265,6 +265,7 @@ zprobe.debounce_ms							1				# Set if noisy
 # zprobe.max_z								100				# max z
 zprobe.calibrate_pin						0.5^			# calibrate_pin
 zprobe.probe_tip_diameter					1.6				#3 axis probe tip diamter
+zprobe.calibration_safety_margin              0.1             # max distance to move after calibrate pin but before probe pin detected
 
 # Leveling strategy
 leveling-strategy.rectangular-grid.enable					true

--- a/src/modules/tools/zprobe/ZProbe.h
+++ b/src/modules/tools/zprobe/ZProbe.h
@@ -75,7 +75,7 @@ class ZProbe: public Module
 {
 
 public:
-    ZProbe() : invert_override(false),invert_probe(false) {};
+    ZProbe() : invert_override(false),invert_probe(false), probe_calibration_safety_margin(0.1F) {};
     virtual ~ZProbe() {};
 
     void on_module_loaded();
@@ -144,6 +144,8 @@ private:
     volatile bool calibrating;
     volatile bool probe_detected;
     volatile bool calibrate_detected;
+
+
     bool bfirstHitDetected  = false;
     bool bNoHited  = false;
     bool bDoubleHited  = false;
@@ -156,6 +158,15 @@ private:
         bool invert_override:1;
         bool invert_probe:1;
     };
+    
+    // Tracking variables to prevent probe crashes
+    // Track position when calibrate pin detected
+    volatile float calibrate_pin_position;  
+    // Track status of calibrate pin
+    volatile bool calibrate_pin_triggered;
+    // zprobe.calibrate_safety_margin
+    float probe_calibration_safety_margin;  
+    
 };
 
 #endif /* ZPROBE_H_ */

--- a/version.txt
+++ b/version.txt
@@ -8,7 +8,7 @@ To let the Carvera work perfectly, please make sure both your controller softwar
 - TLO probe calibration modification to increase accuracy
 - Tools 999990-999999 are for 3 axis probes. Tools outside this range cannot be used for M46X commands
 - added config setting config-set sd zprobe.tool_zero_is_3axis true allows the user to choose if tool 0 is also considered a 3 axis probe
-
+- added config setting config-set sd zprobe.calibration_safety_margin 0.1, during calibration of probe TLO, max distance to move after calibrate pin but before probe pin detected
 
 [1.0.1c1.0.3]
 1. added front button manual tool change behavior


### PR DESCRIPTION
Since read_calibrate now detects whether you're using a probe, and requires both the TLO sensor and probe sensor to activate before halting, we need some protection against crashes.

This could most obviously occur if the probe is disconnected, but could also occur if a NC probe is used since that case is not yet handled for G38.6.

Since the read_calibrate changes are intended to account for minor offsets between activation of the TLO sensor and the tool probe, in the order of 10s of microns, this safety margin value is set to a conservative value of 0.1mm.

This change can be tested by initiating a G38.6 Z-10 F50 probe, then pushing the TLO sensor. The console should report an error that no probe signal was deteced within 0.1mm of Z axis travel.