### PR TITLE
GCC 10.3 support, plus GDB and debug changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,392 @@
 # **Overview**
 
-This is a community branch of the Smoothieware firmware for the Makera Carvera CNC Machine. It is also part of the Carvera Community Org, which includes these other projects:
-[Machine Profiles](https://github.com/Carvera-Community/Carvera_Community_Profiles) - Post processors, 3d design files, and tool libraries for various CAM/CAD programs
+This is a community branch of the Smoothieware firmware for the Makera Carvera
+CNC Machine. It is also part of the Carvera Community Org, which includes these
+other projects: [Machine Profiles](https://github.com/Carvera-Community/Carvera_Community_Profiles) -
+Post processors, 3d design files, and tool libraries for various CAM/CAD
+programs
 
-Open Source Version of the Carvera [Controller](https://github.com/Carvera-Community/CarveraController) - includes builds for linux and macOS. There is a javascript based controller alternative in the works as well
+Open Source Version of the Carvera
+[Controller](https://github.com/Carvera-Community/CarveraController) - includes
+builds for linux and macOS. There is a javascript based controller alternative
+in the works as well
 
-[Trello](https://trello.com/b/qKxPlEbk/carvera-community-firmware-controller-and-other-tech) - for seeing progress on features and making recommendations
+[Trello](https://trello.com/b/qKxPlEbk/carvera-community-firmware-controller-and-other-tech)
+- for seeing progress on features and making recommendations
 
-**NOTE** it is not necessary to build the firmware yourself unless you want to. prebuilt binaries are available [here](https://github.com/Carvera-Community/Carvera_Community_Firmware/releases). There will be periodic stable releases that line up with controller releases, and rolling beta versions to test new features.
+**NOTE** it is not necessary to build the firmware yourself unless you want to.
+prebuilt binaries are available
+[here](https://github.com/Carvera-Community/Carvera_Community_Firmware/releases).
+There will be periodic stable releases that line up with controller releases,
+and rolling beta versions to test new features.
+
+Smoothie is a free, opensource, high performance G-code interpreter and CNC
+controller written in Object-Oriented C++ for the LPC17xx micro-controller ( ARM
+Cortex M3 architecture ). It will run on a mBed, a LPCXpresso, a SmoothieBoard,
+R2C2 or any other LPC17xx-based board. The motion control part is a port of the
+awesome grbl.
+
+# Documentation and resources
+
+- [Community feeds, speeds and
+  accessories](https://docs.google.com/spreadsheets/d/1i9jD0Tg6wzTpGYVqhLZMyLFN7pMlSfdfgpQIxDKbojc/edit) Comprensive
+  resource for G/M codes, config variables, console commands, as well as feeds & speeds recommendations.  
+- [Makera website](https://wiki.makera.com/en/home), [supported codes](https://wiki.makera.com/en/supported-codes), [feeds & speeds](https://wiki.makera.com/en/speeds-and-feeds)
+- [Smoothieware documentation](https://smoothieware.github.io/Webif-pack/documentation/web/html/index.html)
+- [Carvera A to Z](https://carvera-a-to-z.gitbook.io/carvera-a-to-z) - A work in progress wiki for all sorts of information on getting started with the Carvera CNC machine
+
+_**More from the Carvera Community**_
+
+- [Carvera Controller](https://github.com/carvera-community/carvera_controller/) - community controller with extensive additional features and support for community firmware features.
+- [Carvera Community Profiles](https://github.com/Carvera-Community/Carvera_Community_Profiles) - profiles and post-processor for various third party CAM software.
+- [Carvera CLI](https://github.com/hagmonk/carvera-cli) - CLI interface to Carvera for scripting and device management.
+
+_**Other open source tools**_
+
+- https://cc.grid.space/ 
+- https://github.com/GridSpace/carve-control
+- https://github.com/AngryApostrophe/Clout
+- https://cnc.js.org/ 
+- https://github.com/cncjs/cncjs-pendant-boilerplate
 
 
+Work in progress wireless 3 axis touch probe: will be released open source and open hardware along with a purchasable version https://github.com/faecorrigan/Open-Source-3-axis-CNC-Touch-Probe
 
+# Filing issues and contributing 
 
-
-Smoothie is a free, opensource, high performance G-code interpreter and CNC controller written in Object-Oriented C++ for the LPC17xx micro-controller ( ARM Cortex M3 architecture ). It will run on a mBed, a LPCXpresso, a SmoothieBoard, R2C2 or any other LPC17xx-based board. The motion control part is a port of the awesome grbl.
-
-#  **Documentation**:
-[makera website](https://wiki.makera.com/en/home)
-
-[Community Spreadsheet](https://docs.google.com/spreadsheets/d/1i9jD0Tg6wzTpGYVqhLZMyLFN7pMlSfdfgpQIxDKbojc/edit?gid=1892564078#gid=1892564078) includes all the gcodes, mcodes, config variables, and console commands for the machine as well as some tested feeds and speeds and a page on accessories that have been used on the machine.
-
-[Supported G codes](https://wiki.makera.com/en/supported-codes)
-
-[Smoothieware documentation](https://smoothieware.github.io/Webif-pack/documentation/web/html/index.html)
-
-[Carvera A to Z](https://carvera-a-to-z.gitbook.io/carvera-a-to-z) a work in progress wiki for all sorts of information on getting started with the Carvera CNC machine
-
-# **Building Firmware Quick Start**
-
-These are the quick steps to get Smoothie dependencies installed on your computer:
-
-Pull down a clone of the this github project to your local machine.
-
-Download the [launchpad prerequisites](https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/gcc-arm-none-eabi-4_8-2014q1-20140314-win32.zip) and place it in the root folder of this directory.
-
-In the root subdirectory of the cloned project, there are install scripts for the supported platforms. Run the install script appropriate for your platform:
-Windows: win_install.cmd
-OS X: mac_install - I have not tested this yet, but you will probably have to edit the script to remove the command that downlads the gcc-arm-none file that is linked above
-Linux: linux_install - I have not tested this yet, but you will probably have to edit the script to remove the command that downlads the gcc-arm-none file that is linked above
-You can then run the BuildShell script which will be created during the install to properly configure the PATH environment variable to point to the required version of GCC for ARM which was just installed on your machine. You may want to edit this script to further customize your development environment.
-
-note: in this fork, I modified the win_install.cmd by removing lines 44-47 and manually downloading the .zip
-
-### **Building The Firmware**
-Open the BuildShell.cmd and run:
-
-make clean
-
-make all AXIS=5 PAXIS=3 CNC=1
-
-this will create a file in LPC1768/main.bin
-
-rename it to firmware.bin or another name with firmware in it and either upload it using the carvera controller or copy the file to the sdcard and reset your machine.
-
-Filing issues (for bugs ONLY)
-Please follow this guide https://github.com/Smoothieware/Smoothieware/blob/edge/ISSUE_TEMPLATE.md
-
-for more information on compiling smoothieware: Follow this guide... https://smoothieware.github.io/Webif-pack/documentation/web/html/compiling-smoothie.html
-
-# **Contributing**
-Open an [issue](https://github.com/Carvera-Community/Carvera_Community_Firmware/issues) either on github, trello, or message one of the admins. Issues can be for bugfixes or feature requests. 
-
-Test beta versions of the firmware and give bugreports/feedback
-
-Contribute pull requests to the project
-
-contribute to the [A_To_Z wiki](https://github.com/SergeBakharev/carvera_a_to_z)
-
-Please take a look at :
-
-http://smoothieware.org/coding-standards
-
-http://smoothieware.org/developers-guide
-
-http://smoothieware.org/contribution-guidlines
+Please follow [the Smoothieware issue template](https://github.com/Smoothieware/Smoothieware/blob/edge/ISSUE_TEMPLATE.md) when filing bugs against this repo.
 
 Contributions very welcome! 
 
-### **Donate**
-This particular branch of the carvera firmware is maintained by [Fae Corrigan](https://www.patreon.com/propsmonster)
-For smoothieware as a whole: the Smoothie firmware is free software developed by volunteers. If you find this software useful, want to say thanks and encourage development, please consider a [Donation](https://paypal.me/smoothieware)
+- Open an
+[issue](https://github.com/Carvera-Community/Carvera_Community_Firmware/issues)
+either on github, trello, or message one of the admins. Issues can be for
+bugfixes or feature requests. 
+- Test beta versions of the firmware and give bugreports/feedback
+- Contribute pull requests to the project
+- Contribute to the [A_To_Z wiki](https://github.com/SergeBakharev/carvera_a_to_z)
 
-### **License**
-Smoothieware is released under the GNU GPL v3, which you can find at http://www.gnu.org/licenses/gpl-3.0.en.html
-MRI is released under Apache 2.0, which you can find at https://www.apache.org/licenses/LICENSE-2.0
+Carvera Community Firmware uses the same guidelines as upstream Smoothieware
+- http://smoothieware.org/coding-standards
+- http://smoothieware.org/developers-guide
+- http://smoothieware.org/contribution-guidlines
 
-### **Other community resources: **
+# Donate
 
-Open source controllers: 
+This particular branch of the carvera firmware is maintained by [Fae
+Corrigan](https://www.patreon.com/propsmonster) For smoothieware as a whole: the
+Smoothie firmware is free software developed by volunteers. If you find this
+software useful, want to say thanks and encourage development, please consider a
+[Donation](https://paypal.me/smoothieware)
 
-https://cc.grid.space/ 
-https://github.com/GridSpace/carve-control
-https://github.com/AngryApostrophe/Clout
 
-https://cnc.js.org/ 
-https://github.com/cncjs/cncjs-pendant-boilerplate
+# Building the firmware
 
-community feeds, speeds and accessories: https://docs.google.com/spreadsheets/d/1i9jD0Tg6wzTpGYVqhLZMyLFN7pMlSfdfgpQIxDKbojc/edit
+## Toolchain
 
-carvera website: https://www.makera.com/pages/community https://wiki.makera.com/en/home
+There are two GCC toolchains that have been tested with the firmware. In both cases,
+simply ensure the `bin` directory for the toolchain is in your path. For example:
 
-work in progress wireless 3 axis touch probe: will be released open source and open hardware along with a purchasable version https://github.com/faecorrigan/Open-Source-3-axis-CNC-Touch-Probe
+```bash
+PATH=$PATH:$PWD/gcc-arm-none-eabi/bin make ...
+```
+
+### GCC 4.8
+
+This is the ancient toolchain used upstream by Makera and should be the default
+for all users until otherwise advised. Visit
+[Launchpad](https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/) and
+download the _gcc-arm-none-eabi_ variant appropriate for your platform.
+
+### GCC 10.3 (Experimental!!)
+
+The firmware has been updated to support the significantly newer (but still
+quite old) GCC 10.3, which is [available
+here](https://developer.arm.com/downloads/-/gnu-rm). Firmware built with this
+toolchain *has not* undergone rigorous cycle time in real world machines. Once
+stablized we'll continue to push forward and adopt a modern, supported version
+of GCC.
+
+## Build
+
+With the appropriate toolchain in your PATH:
+
+```bash
+# For macOS:
+make -j$(sysctl -n hw.ncpu) AXIS=5 PAXIS=3 CNC=1
+
+# For Linux:
+make -j$(nproc) AXIS=5 PAXIS=3 CNC=1
+
+# For Windows: 
+make -j%NUMBER_OF_PROCESSORS% AXIS=5 PAXIS=3 CNC=1
+```
+
+It's usually advisable to `make clean` regularly. Because `-j` reduces build
+time to <10s on modern hardware, it's feasible to run it prior to every build.
+
+Flags that can be useful:
+
+`VERBOSE=1` prints compiler and linker invocations
+
+`VERSION=string` sets the version string as reported by `version` in the console. This can be
+helpful if you need to verify the bootloader really picked up your new firmware. e.g.
+
+```bash
+make -j($sysctl -n hw.cpu) AXIS=5 PAXIS=3 CNC=1 VERSION=bobby-`date +%Y-%m-%d-%H-%M-%S`
+```
+
+Additional guides related to building Smoothieware [can be found
+here](https://smoothieware.github.io/Webif-pack/documentation/web/html/compiling-smoothie.html).
+
+## Uploading
+
+The build process will output `LPC1768/main.bin`. It should be approximately
+500KB in size. There are several strategies to load this onto the machine.
+
+### Carvera Controller
+
+0. Copy `LP1768/main.bin` to `firmware.bin`
+1. Connect to the machine (note: USB will be quite slow)
+2. Select the hamburger menu (top right)
+3. Choose update (up arrow)
+4. Choose Firmware
+5. Choose Update
+6. Navigate to your local `firmware.bin`
+7. Choose Upload
+8. Choose Reset
+
+### Carvera CLI
+
+Follow instructions to [Install Carvera CLI](https://github.com/hagmonk/carvera-cli/).
+
+```bash
+uvx carvera-cli -d <ip-or-usb-port> upload-firmware --reset ./LPC1768/main.bin
+```
+
+Carvera CLI takes care of naming the file correctly and verifying its MD5. Omit
+`--reset` if you'd like to reset later.
+
+### microSD card
+
+> [!IMPORTANT]
+> Be prepared to do this if you're making significant firmware changes. Trust me!
+
+It's strongly recommended to make a copy of your `config.txt` on the microSD
+card, in case you need to format or replace the card (see below).
+
+On C1 models:
+
+* Although the microSD card is "reachable" without the back cover off, it can
+  be very beneficial to install an microSD extension cable
+* If your Mac/PC has a full sized SD card reader, there are variants that adapt
+  from microSD to SD. 
+* Ensure the connection is snug! I've seen errors that have turned out to be a
+  loosely fitting SD extension cable.
+* It's possible to insert the microSD card, miss the surface mounted slot, and
+  push it into the controller board enclosure. Don't panic! Removing the four
+  phillips head screws from the enclosure will allow you to retrieve it.
+
+_**Prepping the microSD card**_
+
+> [!WARNING]
+> USB-C cable connections will energize the controller board even when mains
+> power is off! Remember to disconnect before removing or inserting the microSD card.
+
+The most reliable process appears to be to remove `FIRMWARE.CUR` and allow the bootloader
+to copy `firmware.bin` over each time.
+
+A paranoid approach (on macOS):
+
+```bash
+md5sum LPC1768/main.bin && \
+    cp LPC1768/main.bin /Volumes/SD/firmware.bin && \
+    [ -f /Volumes/SD/FIRMWARE.CUR ] && \
+    rm /Volumes/SD/FIRMWARE.CUR ;\
+    md5sum /Volumes/SD/firmware.bin && \
+    sleep 1 && \
+    ls -l /Volumes/SD && \
+    diskutil umount /Volumes/SD/
+```
+
+_**Booting from the microSD card**_
+
+0. Ensure the machine is powered down (including controller board!)
+1. Insert the card.
+2. Power on the machine (or energize the controller board if debugging)
+
+After a brief moment of anxiety, the machine should wake up. The front LED (on
+C1 at least) should transition from very dim green, to bright blue, then boot.
+
+*If stuck on dim green* - the bootloader is unhappy with the firmware. This
+could include having used the wrong filename, the firmware is not a valid
+executable, the microSD card cannot be read, and so on.
+
+*If stuck on bright blue but machine is dark, and stays dark* - the bootloader
+jumped into your firmware, but the firmware has not entered the main event loop.
+The most common cause for this will be having used the `ENABLE_DEBUG_MONITOR`
+(see below) and forgotten to remove it. 
+
+*If cycling between dim green and bright blue* - the bootloader is happy, but
+the firmware is not. It is likely this will happen roughly every 10s, as that is
+the default watchdog timeout after which the firmware automatically resets.
+Probable cause will be a firmware crash.
+
+# Debugging
+
+The community firmware supports attaching GDB over a serial connection. A special debug
+build is not required, although some debug specific build flags can be useful.
+
+## Setup
+
+As the serial port is also used for machine control, it's highly recommended to
+disable the use of the serial port for this purpose, allowing GDB to stay
+attached. To send commands to the machine during debugging, use the wifi
+connection via Carvera Controller or Carvera CLI.
+
+Additionally, the watchdog timer **_must be disabled_**, otherwise the device will
+reboot after being trapped by the debugger.
+
+The following flags can be set in config.txt or via the console, after which a
+reboot is required.
+
+```
+# Disable the watchdog timer
+config-set sd watchdog_timeout 0
+
+# Make the serial port exclusive for GDB
+config-set sd disable_serial_console true
+
+# Optional: stop in the debugger if the machine enters a halt state
+config-set sd halt_on_error_debug true
+```
+
+When making deeper modifications to the firmware, troubleshooting boot failures,
+tracking memory allocations, and so on, you will want a firmware build with the
+`ENABLE_DEBUG_MONITOR=1` compile time flag set. This flag traps the debugger
+during [build/mbed_custom.cpp](build/mbed_custom.cpp) in `_start`, about as
+early in the firmware as you can get. Not just prior to `main()`, but prior to
+to C++ static constructors, SRAM region setup, etc.
+
+> [!IMPORTANT]
+> Another reminder that the USB-C connection will power the controller board.
+> You can get a surprising amount of work done without turning on mains power!
+
+Before starting work with GDB, it can be helpful to create a `.gdbinit` file that
+instructs GDB to remember your command history:
+
+```gdb
+# in ~/.gdbinit
+set history save on
+set history filename ~/.gdb_history
+set history size 10000
+```
+
+## Attaching GDB
+
+Use the GDB in your toolchain. Symbols are available alongside the firmware binary
+at `LPC1768/main.elf`. 
+
+> [!IMPORTANT] 
+> Ensure that your `main.bin`, `main.elf`, and source code all line
+> up exactly. Otherwise you will have a very confusing debug experience.
+
+```bash
+./gcc-arm-none-eabi/bin/arm-none-eabi-gdb LPC1768/main.elf --baud 115200 \
+    -ex "set target-charset ASCII" \
+    -ex "set remotelogfile mri.log" \
+    -ex "target remote <your serial dev>"
+```
+
+`mri.log` contains a log of the read/write communication between GDB and the device. 
+This can be handy when verifying if the device stopped responding.
+
+> [!WARNING]
+> Since the GCC 4.8 toolchain is old enough to go to the cinema by itself, at
+> least on macOS it's not possible to use that toolchain for GDB. Thankfully,
+> GDB is still GDB, and you can happily use a working GDB from a modern
+> toolchain to attach.
+
+## Handy GDB tips
+
+This isn't intended as a complete guide to GDB; the internet is full of great
+resources to learn the basics. AI assistants can be extremely helpful!
+
+### Controlling execution
+
+* Hit `ctrl-c`. You will end up at whatever random instruction happened to be
+  running at that moment.
+* Enable `halt_on_error_debug` to stop execution on HALT.
+* Add a call to `__debugbreak` in your code. Don't use this for regular
+  debugging (use breakpoints), instead use this as a kind of "assert" to stop
+  execution in unexpected places.
+* Send `break` in the console over wifi
+
+Note the debugger will also be triggered in the event of an unhandled signal
+like a segmentation fault.
+
+### Force restart
+
+Since you must have the watchdog disabled to get any work done in GDB, you need
+some way to recover from a crash or other situations where execution can't be
+continued, or when you can't reach the console over wifi.
+
+Luckily the device's architecture lets you set a specific value to the AIR
+register in the SCB block to restart the device. As long as GDB is still able
+to talk to the device, you should be able to run:
+
+```gdb
+set {uint32_t}0xE000ED0C = 0x05FA0004
+```
+
+### Reconnecting
+
+When the firmware restarts, you'll lose your GDB connection. Rather than
+restarting GDB, you can run:
+
+```gdb
+target remote <your serial dev>
+```
+
+### Scripting
+
+Without turning this into a full guide on GDB, it's worth noting that you will
+rapidly find a need for aliasing common commands and running pre-canned routines
+repeatedly.
+
+These can be placed in your `~/.gdbinit` or loaded from a file in GDB with
+`source`. 
+
+```gdb
+# alias commands
+alias -a binit = "break main.cpp:init"
+
+# define a command
+define dumpmem
+  echo --- Memory Pool Dump ---\n
+  p _AHB0
+  p _AHB1
+end
+
+# run a command every time you run 'next'
+define hook-next
+    dumpmem
+end
+
+# run commands when a breakpoint is hit
+break MemoryPool::alloc if nbytes >= 5000
+commands
+  printf "--- Large AHB Pool Allocation (%lu bytes) ---\n", nbytes
+  printf "Call Stack:\n"
+  bt
+  printf "--------------------------------------------\n"
+  cont
+end
+```
+
+# License
+
+Smoothieware is released under the GNU GPL v3, which you can find at
+http://www.gnu.org/licenses/gpl-3.0.en.html MRI is released under Apache 2.0,
+which you can find at https://www.apache.org/licenses/LICENSE-2.0
+

--- a/build/common.mk
+++ b/build/common.mk
@@ -38,6 +38,11 @@ else
 Q=
 endif
 
+GCC_VERSION := $(shell $(CXX) -dumpversion)
+GCC_MAJOR := $(shell echo $(GCC_VERSION) | cut -f1 -d.)
+GCC_MINOR := $(shell echo $(GCC_VERSION) | cut -f2 -d.)
+IS_GCC_10_3_OR_LATER := $(shell expr \( $(GCC_MAJOR) -gt 10 \) \| \( $(GCC_MAJOR) -eq 10 \& $(GCC_MINOR) -ge 3 \))
+
 
 # Default variables.
 SRC ?= .
@@ -197,11 +202,15 @@ GCFLAGS += -ffunction-sections -fdata-sections  -fno-exceptions -fno-delete-null
 GCFLAGS += $(patsubst %,-I%,$(INCDIRS))
 GCFLAGS += $(DEFINES)
 GCFLAGS += $(DEPFLAGS)
-GCFLAGS += -Wall -Wextra -Wno-unused-parameter -Wcast-align \
- -Wpointer-arith -Wredundant-decls -Wcast-qual -Wcast-align \
- -fanalyzer -fomit-frame-pointer -floop-unroll-and-jam \
- -floop-interchange -fstack-clash-protection -mfix-cortex-m3-ldrd \
- -ftree-vectorize -munaligned-access
+GCFLAGS += -Wall -Wextra -Wno-unused-parameter -fomit-frame-pointer \
+ -Wpointer-arith -Wredundant-decls -Wcast-qual -Wcast-align
+
+ifeq ($(IS_GCC_10_3_OR_LATER),1)
+GCFLAGS += -fanalyzer-floop-unroll-and-jam \
+	-floop-interchange -fstack-clash-protection -mfix-cortex-m3-ldrd \
+ 	-ftree-vectorize -munaligned-access
+endif
+
 
 GPFLAGS += $(GCFLAGS) -fno-rtti -std=gnu++11
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -197,7 +197,11 @@ GCFLAGS += -ffunction-sections -fdata-sections  -fno-exceptions -fno-delete-null
 GCFLAGS += $(patsubst %,-I%,$(INCDIRS))
 GCFLAGS += $(DEFINES)
 GCFLAGS += $(DEPFLAGS)
-GCFLAGS += -Wall -Wextra -Wno-unused-parameter -Wcast-align -Wpointer-arith -Wredundant-decls -Wcast-qual -Wcast-align
+GCFLAGS += -Wall -Wextra -Wno-unused-parameter -Wcast-align \
+ -Wpointer-arith -Wredundant-decls -Wcast-qual -Wcast-align \
+ -fanalyzer -fomit-frame-pointer -floop-unroll-and-jam \
+ -floop-interchange -fstack-clash-protection -mfix-cortex-m3-ldrd \
+ -ftree-vectorize -munaligned-access
 
 GPFLAGS += $(GCFLAGS) -fno-rtti -std=gnu++11
 

--- a/build/mbed_custom.cpp
+++ b/build/mbed_custom.cpp
@@ -19,6 +19,8 @@
 #include <mri.h>
 #include <cmsis.h>
 #include "mpu.h"
+#include <new>
+#include <type_traits>
 
 #include "platform_memory.h"
 
@@ -36,6 +38,10 @@ extern unsigned int     __bss_start__;
 extern unsigned int     __bss_end__;
 extern unsigned int     __StackTop;
 extern "C" unsigned int __end__;
+
+// Allocate static raw memory buffers aligned and sized for MemoryPool objects
+// Use __attribute__ for alignment
+static typename std::aligned_storage<sizeof(MemoryPool), alignof(MemoryPool)>::type _ahb_pool_mem;
 
 extern "C" int  main(void);
 extern "C" void __libc_init_array(void);
@@ -65,23 +71,19 @@ extern "C" void _start(void)
 
     // MemoryPool stuff - needs to be initialised before __libc_init_array
     // so static ctors can use them
-    extern uint8_t __AHB0_block_start;
-    extern uint8_t __AHB0_dyn_start;
-    extern uint8_t __AHB0_end;
-    extern uint8_t __AHB1_block_start;
-    extern uint8_t __AHB1_dyn_start;
-    extern uint8_t __AHB1_end;
+    extern uint8_t __AHB_block_start;
+    extern uint8_t __AHB_dyn_start;
+    extern uint8_t __AHB_end;
 
-    // zero the data sections in AHB0 and AHB1
-    memset(&__AHB0_block_start, 0, &__AHB0_dyn_start - &__AHB0_block_start);
-    memset(&__AHB1_block_start, 0, &__AHB1_dyn_start - &__AHB1_block_start);
+    // zero the data sections in AHB
+    memset(&__AHB_block_start, 0, &__AHB_dyn_start - &__AHB_block_start);
 
-    MemoryPool _AHB0_stack(&__AHB0_dyn_start, &__AHB0_end - &__AHB0_dyn_start);
-    MemoryPool _AHB1_stack(&__AHB1_dyn_start, &__AHB1_end - &__AHB1_dyn_start);
+    // Construct the MemoryPool objects in the statically allocated raw buffers
+    // using placement new.
+    new (&_ahb_pool_mem) MemoryPool(&__AHB_dyn_start, &__AHB_end - &__AHB_dyn_start);
 
-
-    _AHB0 = &_AHB0_stack;
-    _AHB1 = &_AHB1_stack;
+    // Assign the addresses of the constructed objects (in the buffers) to the global pointers
+    _ahb = reinterpret_cast<MemoryPool*>(&_ahb_pool_mem);
     // MemoryPool init done
 
     __libc_init_array();

--- a/mbed/src/vendor/NXP/cmsis/LPC1768/ARM/LPC1768.sct
+++ b/mbed/src/vendor/NXP/cmsis/LPC1768/ARM/LPC1768.sct
@@ -10,11 +10,8 @@ LR_IROM1 0x00000000 0x80000  {    ; load region size_region
   RW_IRAM1 0x100000C8 0x7F38  {
    .ANY (+RW +ZI)
   }
-  RW_IRAM2 0x2007C000 0x4000  {  ; RW data, ETH RAM
-   .ANY (AHBSRAM0)
-  }
-  RW_IRAM3 0x20080000 0x4000  {  ; RW data, ETH RAM
-   .ANY (AHBSRAM1)
+  RW_IRAM2 0x2007C000 0x8000  {  ; RW data, AHB RAM
+   .ANY (AHBSRAM)
   }
   RW_IRAM4 0x40038000 0x0800  {  ; RW data, CAN RAM
    .ANY (CANRAM)

--- a/mbed/src/vendor/NXP/cmsis/LPC1768/GCC_ARM/LPC1768.ld
+++ b/mbed/src/vendor/NXP/cmsis/LPC1768/GCC_ARM/LPC1768.ld
@@ -5,8 +5,7 @@ MEMORY
   FLASH (rx) : ORIGIN = 16K, LENGTH = (512K - 16K)
   RAM (rwx) : ORIGIN = 0x100000C8, LENGTH = (32K - 0xC8)
 
-  USB_RAM(rwx) : ORIGIN = 0x2007C000, LENGTH = 16K
-  ETH_RAM(rwx) : ORIGIN = 0x20080000, LENGTH = 16K
+  AHB_SRAM(rwx) : ORIGIN = 0x2007C000, LENGTH = 32K
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -155,26 +154,27 @@ SECTIONS
 
 
     /* Code can explicitly ask for data to be 
-       placed in these higher RAM banks where
-       they will be left uninitialized. 
+        placed in these higher RAM banks where
+        they will be left uninitialized.
     */
-    .AHBSRAM0 (NOLOAD):
-    {
-        Image$$RW_IRAM2$$Base = . ;
-        PROVIDE(__AHB0_block_start = .);
-        *(AHBSRAM0)
-        Image$$RW_IRAM2$$ZI$$Limit = .;
-        PROVIDE(__AHB0_dyn_start = .);
-        PROVIDE(__AHB0_end = ORIGIN(USB_RAM) + LENGTH(USB_RAM));
-    } > USB_RAM
 
-    .AHBSRAM1 (NOLOAD):
+    .AHBSRAM (NOLOAD) :
     {
-        Image$$RW_IRAM3$$Base = . ;
-        PROVIDE(__AHB1_block_start = .);
-        *(AHBSRAM1)
-        Image$$RW_IRAM3$$ZI$$Limit = .;
-        PROVIDE(__AHB1_dyn_start = .);
-        PROVIDE(__AHB1_end = ORIGIN(ETH_RAM) + LENGTH(ETH_RAM));
-    } > ETH_RAM
+        Image$$RW_IRAM1$$Base = . ;
+        PROVIDE(__AHB_block_start = .);
+
+        . = ALIGN(4);
+
+        PROVIDE(__ohci_registers_t_start = Image$$RW_IRAM1$$Base);
+
+        /* Reserve 0x200 bytes for USB OHCI controller registers */
+        . = . + 0x200;
+
+        PROVIDE(__ohci_registers_t_end = .);
+
+        *(AHBSRAM)
+        Image$$RW_IRAM1$$ZI$$Limit = .;
+        PROVIDE(__AHB_dyn_start = .);
+        PROVIDE(__AHB_end = ORIGIN(AHB_SRAM) + LENGTH(AHB_SRAM));
+    } > AHB_SRAM
 }

--- a/src/config.default
+++ b/src/config.default
@@ -19,6 +19,7 @@ new_status_format							true
 
 # USB
 # usb_en_pin								1.19
+disable_serial_console						false           # Disable serial console (to reserve for MRI/GDB)
 
 # Basic motion configuration
 #default_feed_rate							1000			# Default speed (mm/minute) for G1/G2/G3 moves

--- a/src/config2.default
+++ b/src/config2.default
@@ -19,6 +19,7 @@ new_status_format							true
 
 # USB
 # usb_en_pin								1.19
+disable_serial_console						false           # Disable serial console (to reserve for MRI/GDB)
 
 # Basic motion configuration
 #default_feed_rate							1000			# Default speed (mm/minute) for G1/G2/G3 moves

--- a/src/libs/ConfigCache.cpp
+++ b/src/libs/ConfigCache.cpp
@@ -43,7 +43,7 @@ void ConfigCache::replace_or_push_back(ConfigValue *new_value)
             // Replace with the provided value
             delete cv; // free up old one
             cv =  new_value;
-            printf("WARNING: duplicate config line replaced\n");
+            // printf("WARNING: duplicate config line replaced\n");
             return;
         }
     }

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -59,7 +59,8 @@
 #define grbl_mode_checksum                          CHECKSUM("grbl_mode")
 #define feed_hold_enable_checksum                   CHECKSUM("enable_feed_hold")
 #define ok_per_line_checksum                        CHECKSUM("ok_per_line")
-
+#define disable_serial_console_checksum             CHECKSUM("disable_serial_console")
+#define halt_on_error_debug_checksum                CHECKSUM("halt_on_error_debug")
 Kernel* Kernel::instance;
 
 #define	EEP_MAX_PAGE_SIZE	32
@@ -89,6 +90,7 @@ Kernel::Kernel()
     checkled = false;
     spindleon = false;
     cachewait = false;
+    disable_serial_console = false;
 
     instance = this; // setup the Singleton instance of the kernel    
     
@@ -102,56 +104,18 @@ Kernel::Kernel()
     // read Factory settings data from sd
     this->read_Factroy_SD();
 
-    // serial first at fixed baud rate (DEFAULT_SERIAL_BAUD_RATE) so config can report errors to serial
-    // Set to UART0, this will be changed to use the same UART as MRI if it's enabled
-    this->serial = new(AHB) SerialConsole(P2_8, P2_9, DEFAULT_SERIAL_BAUD_RATE);
-    // this->serial = new SerialConsole(USBTX, USBRX, DEFAULT_SERIAL_BAUD_RATE);
 
     // Config next, but does not load cache yet
     this->config = new(AHB) Config();
 
-    // Pre-load the config cache, do after setting up serial so we can report errors to serial
+    // Pre-load the config cache
     this->config->config_cache_load();
-
-    // now config is loaded we can do normal setup for serial based on config
-    delete this->serial;
-    this->serial = NULL;
 
     this->streams = new(AHB) StreamOutputPool();
 
     this->current_path   = "/";
 
-    // Configure UART depending on MRI config
-    // Match up the SerialConsole to MRI UART. This makes it easy to use only one UART for both debug and actual commands.
     NVIC_SetPriorityGrouping(0);
-
-    /*
-#if MRI_ENABLE != 0
-    switch( __mriPlatform_CommUartIndex() ) {
-        case 0:
-            this->serial = new(AHB) SerialConsole(P2_8, P2_9, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
-            break;
-        case 1:
-            this->serial = new(AHB) SerialConsole(  p13,   p14, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
-            break;
-        case 2:
-            this->serial = new(AHB) SerialConsole(  p28,   p27, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
-            break;
-        case 3:
-            this->serial = new(AHB) SerialConsole(   p9,   p10, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
-            break;
-    }
-#endif*/
-
-    // init FT232
-
-
-    // default
-    if(this->serial == NULL) {
-        // this->serial = new(AHB) SerialConsole(P2_8, P2_9, this->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
-    	this->serial = new(AHB) SerialConsole(P2_8, P2_9, 115200);
-    }
-
     //some boards don't have leds.. TOO BAD!
     this->use_leds = !this->config->value( disable_leds_checksum )->by_default(false)->as_bool();
 
@@ -166,7 +130,18 @@ Kernel::Kernel()
     // we expect ok per line now not per G code, setting this to false will return to the old (incorrect) way of ok per G code
     this->ok_per_line = this->config->value( ok_per_line_checksum )->by_default(true)->as_bool();
 
-    this->add_module( this->serial );
+    // Option to disable serial console. Useful primarily if MRI is enabled and
+    // you want to keep the serial port dedicated for such traffic. Or you want
+    // to save some memory?
+    this->disable_serial_console = this->config->value( disable_serial_console_checksum )->by_default(false)->as_bool();
+    
+    // Check if we should break into the debugger on halt
+    this->halt_on_error_debug = this->config->value( halt_on_error_debug_checksum )->by_default(false)->as_bool();
+
+    if (!this->disable_serial_console) {
+        this->serial = new(AHB) SerialConsole(P2_8, P2_9, 115200);
+        this->add_module( this->serial );
+    }
 
     // HAL stuff
     add_module( this->slow_ticker = new(AHB) SlowTicker());
@@ -652,6 +627,12 @@ void Kernel::call_event(_EVENT_ENUM id_event, void * argument)
     }
 
     if(id_event == ON_HALT) {
+        // If we just entered a halt state AND the debug flag is enabled, break into the debugger.
+        // This happens after ON_HALT handlers have run, presumably stopping motion planners etc.
+        if (this->halted && this->halt_on_error_debug) {
+             __debugbreak(); // Enter debugger
+        }
+
         if(!this->halted || !was_idle) {
             // if we were running and this is a HALT
             // or if we are clearing the halt with $X or M999

--- a/src/libs/Kernel.cpp
+++ b/src/libs/Kernel.cpp
@@ -96,7 +96,7 @@ Kernel::Kernel()
     this->i2c = new mbed::I2C(P0_27, P0_28);
     this->i2c->frequency(200000);
     
-    this->factory_set = new(AHB0) FACTORY_SET();
+    this->factory_set = new(AHB) FACTORY_SET();
     // read Factory setting data from eeprom
     this->read_Factory_data();
     // read Factory settings data from sd
@@ -104,11 +104,11 @@ Kernel::Kernel()
 
     // serial first at fixed baud rate (DEFAULT_SERIAL_BAUD_RATE) so config can report errors to serial
     // Set to UART0, this will be changed to use the same UART as MRI if it's enabled
-    this->serial = new(AHB0) SerialConsole(P2_8, P2_9, DEFAULT_SERIAL_BAUD_RATE);
+    this->serial = new(AHB) SerialConsole(P2_8, P2_9, DEFAULT_SERIAL_BAUD_RATE);
     // this->serial = new SerialConsole(USBTX, USBRX, DEFAULT_SERIAL_BAUD_RATE);
 
     // Config next, but does not load cache yet
-    this->config = new(AHB0) Config();
+    this->config = new(AHB) Config();
 
     // Pre-load the config cache, do after setting up serial so we can report errors to serial
     this->config->config_cache_load();
@@ -117,7 +117,7 @@ Kernel::Kernel()
     delete this->serial;
     this->serial = NULL;
 
-    this->streams = new(AHB0) StreamOutputPool();
+    this->streams = new(AHB) StreamOutputPool();
 
     this->current_path   = "/";
 
@@ -129,16 +129,16 @@ Kernel::Kernel()
 #if MRI_ENABLE != 0
     switch( __mriPlatform_CommUartIndex() ) {
         case 0:
-            this->serial = new(AHB0) SerialConsole(P2_8, P2_9, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
+            this->serial = new(AHB) SerialConsole(P2_8, P2_9, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
             break;
         case 1:
-            this->serial = new(AHB0) SerialConsole(  p13,   p14, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
+            this->serial = new(AHB) SerialConsole(  p13,   p14, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
             break;
         case 2:
-            this->serial = new(AHB0) SerialConsole(  p28,   p27, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
+            this->serial = new(AHB) SerialConsole(  p28,   p27, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
             break;
         case 3:
-            this->serial = new(AHB0) SerialConsole(   p9,   p10, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
+            this->serial = new(AHB) SerialConsole(   p9,   p10, this->config->value(uart0_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
             break;
     }
 #endif*/
@@ -148,8 +148,8 @@ Kernel::Kernel()
 
     // default
     if(this->serial == NULL) {
-        // this->serial = new(AHB0) SerialConsole(P2_8, P2_9, this->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
-    	this->serial = new(AHB0) SerialConsole(P2_8, P2_9, 115200);
+        // this->serial = new(AHB) SerialConsole(P2_8, P2_9, this->config->value(uart_checksum, baud_rate_setting_checksum)->by_default(DEFAULT_SERIAL_BAUD_RATE)->as_number());
+    	this->serial = new(AHB) SerialConsole(P2_8, P2_9, 115200);
     }
 
     //some boards don't have leds.. TOO BAD!
@@ -169,10 +169,10 @@ Kernel::Kernel()
     this->add_module( this->serial );
 
     // HAL stuff
-    add_module( this->slow_ticker = new(AHB0) SlowTicker());
+    add_module( this->slow_ticker = new(AHB) SlowTicker());
 
-    this->step_ticker = new(AHB0) StepTicker();
-    this->adc = new(AHB0) Adc();
+    this->step_ticker = new(AHB) StepTicker();
+    this->adc = new(AHB) Adc();
 
     // TODO : These should go into platform-specific files
     // LPC17xx-specific
@@ -208,20 +208,20 @@ Kernel::Kernel()
     this->step_ticker->set_frequency( this->base_stepping_frequency );
     this->step_ticker->set_unstep_time( microseconds_per_step_pulse );
 
-    this->eeprom_data = new(AHB0) EEPROM_data();
+    this->eeprom_data = new(AHB) EEPROM_data();
     // read eeprom data
     this->read_eeprom_data();
     // check eeprom data
     this->check_eeprom_data();
 
     // Core modules
-    this->add_module( this->conveyor       = new(AHB0) Conveyor()      );
-    this->add_module( this->gcode_dispatch = new(AHB0) GcodeDispatch() );
-    this->add_module( this->robot          = new(AHB0) Robot()         );
-    this->add_module( this->simpleshell    = new(AHB0) SimpleShell()   );
+    this->add_module( this->simpleshell    = new(AHB) SimpleShell()   );
+    this->add_module( this->conveyor       = new(AHB) Conveyor()      );
+    this->add_module( this->gcode_dispatch = new(AHB) GcodeDispatch() );
+    this->add_module( this->robot          = new(AHB) Robot()         );
 
-    this->planner = new(AHB0) Planner();
-    this->configurator = new(AHB0) Configurator();
+    this->planner = new(AHB) Planner();
+    this->configurator = new(AHB) Configurator();
 }
 
 // get current state

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -17,6 +17,8 @@
 #include <array>
 #include <vector>
 #include <string>
+#include "modules/utils/wifi/WifiProvider.h"
+#include "libs/USBDevice/MSCFileSystem.h"
 
 // 9 WCS offsets
 #define MAX_WCS 9UL

--- a/src/libs/Kernel.h
+++ b/src/libs/Kernel.h
@@ -263,6 +263,8 @@ class Kernel {
             bool zprobing:1;
             bool probeLaserOn:1;
             volatile bool cachewait:1;
+            bool disable_serial_console:1;
+            bool halt_on_error_debug:1;
         };
         int iic_page_write(unsigned char u8PageNum, unsigned char u8len, unsigned char *pu8Array);
 

--- a/src/libs/MemoryPool.cpp
+++ b/src/libs/MemoryPool.cpp
@@ -77,6 +77,11 @@ MemoryPool::~MemoryPool()
 
 void* MemoryPool::alloc(size_t nbytes)
 {
+    // Instrumentation: print allocation size and both possible caller addresses for AHB0
+    // extern MemoryPool* _AHB0;
+    // if (this == _AHB0) {
+    //     printf("[AHB0] alloc size=%u caller0=%p caller1=%p\n", (unsigned)nbytes, __builtin_return_address(0), __builtin_return_address(1));
+    // }
     // nbytes = ceil(nbytes / 4) * 4
     if (nbytes & 3)
         nbytes += 4 - (nbytes & 3);

--- a/src/libs/MemoryPool.cpp
+++ b/src/libs/MemoryPool.cpp
@@ -77,11 +77,6 @@ MemoryPool::~MemoryPool()
 
 void* MemoryPool::alloc(size_t nbytes)
 {
-    // Instrumentation: print allocation size and both possible caller addresses for AHB0
-    // extern MemoryPool* _AHB0;
-    // if (this == _AHB0) {
-    //     printf("[AHB0] alloc size=%u caller0=%p caller1=%p\n", (unsigned)nbytes, __builtin_return_address(0), __builtin_return_address(1));
-    // }
     // nbytes = ceil(nbytes / 4) * 4
     if (nbytes & 3)
         nbytes += 4 - (nbytes & 3);
@@ -104,17 +99,18 @@ void* MemoryPool::alloc(size_t nbytes)
             p->used = 1;
 
             // if there's free space at the end of this block
-            if (p->next > nsize)
+            // Ensure there's enough space for a new header plus minimal data (e.g., 4 bytes aligned)
+            if (p->next >= (nsize + sizeof(_poolregion) + 4)) // Check if remaining space is usable
             {
-                // q = p->next
+                // q points to the start of the remaining free space
                 _poolregion* q = (_poolregion*) (((uint8_t*) p) + nsize);
 
                 MDEBUG("\t\twriting header to %p (%+d) (%d)\n", q, offset(q), p->next - nsize);
                 // write a new block header into q
                 q->used = 0;
-                q->next = p->next - nsize;
+                q->next = p->next - nsize; // Size of the new free block
 
-                // set our next to point to it
+                // Update the size of the newly allocated block
                 p->next = nsize;
 
                 // sanity check
@@ -124,111 +120,208 @@ void* MemoryPool::alloc(size_t nbytes)
                     // this can only happen if something has corrupted our heap, since we should simply fail to find a free block if it's full
                     __debugbreak();
                 }
-            }
+            } // else: remaining space is too small to create a new block, so the allocated block takes it all (p->next remains unchanged)
 
             // then return the data region for the block
             return &p->data;
         }
 
+        // Check if we've reached the end of the pool without finding a suitable block
+        if (offset(p) + p->next >= size) {
+            break; // Reached the end of the pool structure
+        }
+
         // p = p->next
-        p = (_poolregion*) (((uint8_t*) p) + p->next);
+         _poolregion* next_p = (_poolregion*) (((uint8_t*) p) + p->next);
 
-        // make sure we don't walk off the end
-    } while (p < (_poolregion*) (((uint8_t*)base) + size));
+        // Safety check: avoid infinite loop or invalid pointers if pool metadata is corrupted
+        if (next_p >= (_poolregion*) (((uint8_t*) base) + size) || next_p <= p || next_p->next == 0 ) {
+             // Consider logging an error or handling corruption
+             break; // Exit loop if metadata seems corrupt
+        }
+        p = next_p;
 
-    // fell off the end of the region!
+    } while (1);
+
+    // fell off the end of the region or couldn't find a block!
     return NULL;
 }
 
 void MemoryPool::dealloc(void* d)
 {
-    _poolregion* p = (_poolregion*) (((uint8_t*) d) - sizeof(_poolregion));
-    p->used = 0;
-
-    MDEBUG("\tdeallocating %p (%+d, %db)\n", p, offset(p), p->next);
-
-    // combine next block if it's free
-    _poolregion* q = (_poolregion*) (((uint8_t*) p) + p->next);
-    if(q >= (_poolregion*) (((uint8_t*) base) + size)) {
-        // we are beyond the end of the pool, ie last block
+    // Check for null pointer deallocation
+    if (d == nullptr) {
+        MDEBUG("\tAttempted to dealloc a null pointer\n");
         return;
     }
 
-    if (q->used == 0)
-    {
-        MDEBUG("\t\tCombining with next free region at %p, new size is %d\n", q, p->next + q->next);
-
-        // sanity check
-        if (offset(q) > size)
-        {
-            // captain, we have a problem!
-            // this can only happen if something has corrupted our heap, since we should simply fail to find a free block if it's full
-            __debugbreak();
-        }
-
-        p->next += q->next;
+    // Check if the pointer is within the pool's bounds before calculating header address
+    if (!has(d)) {
+        MDEBUG("\tAttempted to dealloc pointer %p outside of pool %p bounds [%p, %p)\n", d, this, base, ((uint8_t*) base) + size);
+        // Optionally, could call ::free(d) here if that's the desired fallback, but risky.
+        // Or trigger an error/assert.
+        return;
     }
 
-    // walk the list to find previous block
-    q = (_poolregion*) base;
-    do {
-        // check if q is the previous block
-        if ((((uint8_t*) q) + q->next) == (uint8_t*) p) {
-            // q is the previous block.
-            if (q->used == 0)
-            { // if q is free
-                MDEBUG("\t\tCombining with previous free region at %p, new size is %d\n", q, p->next + q->next);
+    _poolregion* p = (_poolregion*) (((uint8_t*) d) - sizeof(_poolregion));
 
-                // combine!
-                q->next += p->next;
+    // Sanity check: Ensure calculated header is within bounds and looks plausible
+    if (((uint8_t*)p < (uint8_t*)base) || ((uint8_t*)p >= ((uint8_t*)base + size))) {
+        MDEBUG("\tCalculated header %p for data %p is outside pool bounds\n", p, d);
+        __debugbreak(); // Likely memory corruption
+        return;
+    }
 
-                // sanity check
-                if ((offset(p) + p->next) > size)
-                {
-                    // captain, we have a problem!
-                    // this can only happen if something has corrupted our heap, since we should simply fail to find a free block if it's full
-                    __debugbreak();
+    // Check if the block is already marked as free (double free)
+    if (p->used == 0) {
+        MDEBUG("\tAttempted double free on block at %p (%+d)\n", p, offset(p));
+        // __debugbreak(); // Optional: break on double free
+        return;
+    }
+
+    p->used = 0;
+    MDEBUG("\tdeallocating %p (%+d, %db)\n", p, offset(p), p->next);
+
+    // --- Coalesce with the next block --- 
+    _poolregion* q_next = (_poolregion*) (((uint8_t*) p) + p->next);
+
+    // Check if q_next is within the pool boundary before accessing its members
+    if(q_next < (_poolregion*) (((uint8_t*) base) + size)) {
+        // Now safe to check if the next block is free
+        if (q_next->used == 0)
+        {
+            MDEBUG("\t\tCombining with next free region at %p, new size is %d\n", q_next, p->next + q_next->next);
+            
+            // Sanity check before merging
+            if ((offset(p) + p->next + q_next->next) > size) {
+                 MDEBUG("\t\t\tERROR: Merge with next block would exceed pool size!\n");
+                 __debugbreak(); // Heap corruption likely
+            } else {
+                p->next += q_next->next; // Merge: increase current block's size
+            }
+        }
+    } else {
+         MDEBUG("\t\tReached end of pool, no next block to coalesce.\n");
+    }
+
+    // --- Coalesce with the previous block --- 
+    // Walk the list to find the block *before* p
+    _poolregion* q_prev = (_poolregion*) base;
+    while (q_prev < p) { // Iterate until we find the block whose 'next' points to p
+        _poolregion* potential_next = (_poolregion*) (((uint8_t*) q_prev) + q_prev->next);
+        
+        if (potential_next == p) { // Found the previous block (q_prev)
+            if (q_prev->used == 0) { // If the previous block is free
+                MDEBUG("\t\tCombining with previous free region at %p, new size is %d\n", q_prev, q_prev->next + p->next);
+                
+                // Sanity check before merging
+                if ((offset(q_prev) + q_prev->next + p->next) > size) {
+                    MDEBUG("\t\t\tERROR: Merge with previous block would exceed pool size!\n");
+                    __debugbreak(); // Heap corruption likely
+                } else {
+                    q_prev->next += p->next; // Merge: increase previous block's size
+                    // p is now merged into q_prev, no further action needed for p
                 }
             }
-
-            // we found previous block, return
-            return;
+            // Whether merged or not, we found the previous block and are done.
+            return; 
         }
 
-        // return if last block
-        if (offset(q) + q->next >= size)
-            return;
+        // Check for end condition or corruption before advancing q_prev
+        if (offset(q_prev) + q_prev->next >= size || q_prev->next <= sizeof(_poolregion)) {
+            MDEBUG("\t\tCould not find previous block for %p during backward coalesce check (end reached or corruption?).\n", p);
+            return; // Stop if we hit the end or see a bad size
+        }
 
-        // q = q->next
-        q = (_poolregion*) (((uint8_t*) q) + q->next);
+        // Move to the next block in the list
+        q_prev = potential_next;
 
-        // if some idiot deallocates our memory region while we're using it, strange things can happen.
-        // avoid an infinite loop in that case, however we'll still leak memory and may corrupt things
-        if (q->next == 0)
-            return;
-
-        // make sure we don't walk off the end
-    } while (q < (_poolregion*) (((uint8_t*) base) + size));
+        // Additional safety check for infinite loops
+        if (q_prev >= (_poolregion*) (((uint8_t*) base) + size) || q_prev->next == 0 ) {
+             MDEBUG("\t\tPool metadata might be corrupted during backward coalesce check. Aborting search.\n");
+             return;
+        }
+    }
+    // If loop finishes without returning, it means p was the first block, so no previous to merge with.
+     MDEBUG("\t\tBlock %p is the first block, no previous block to coalesce.\n", p);
 }
 
 void MemoryPool::debug(StreamOutput* str)
 {
     _poolregion* p = (_poolregion*) base;
-    uint32_t tot = 0;
-    uint32_t free = 0;
-    str->printf("Start: %ub MemoryPool at %p\n", size, p);
+    uint32_t total_used = 0;
+    uint32_t total_fragmented_free = 0;
+    uint32_t unallocated_at_end = 0; // Size of the last block if it's free and touches the end
+    str->printf("Start: %u MemoryPool at %p\n", size, p);
+
     do {
         str->printf("\tChunk at %p (%4lu): %s, %lu bytes\n", p, offset(p), (p->used?"used":"free"), p->next);
-        tot += p->next;
-        if (p->used == 0)
-            free += p->next;
-        if ((offset(p) + p->next >= size) || (p->next <= sizeof(_poolregion)))
-        {
-            str->printf("End: total %lub, free: %lub\n", tot, free);
-            return;
+
+        bool is_last_block = (offset(p) + p->next >= size);
+
+        if (p->used) {
+            total_used += p->next;
+        } else {
+            // If this free block is the very last one in the pool
+            if (is_last_block) {
+                 unallocated_at_end = p->next; // Attributing the final free block correctly
+            } else {
+                total_fragmented_free += p->next; // It's a free fragment somewhere in the middle
+            }
         }
-        p = (_poolregion*) (((uint8_t*) p) + p->next);
+
+        // Check loop termination condition
+        if (is_last_block || p->next <= sizeof(_poolregion)) {
+             break; // Reached end or invalid block size
+        }
+
+        // Move to the next block
+        _poolregion* next_p = (_poolregion*) (((uint8_t*) p) + p->next);
+
+        // Safety check: avoid infinite loop or going past end if pool metadata is corrupted
+        // Check if next_p is beyond the pool, not pointing forward, or has zero size
+        if (next_p >= (_poolregion*) (((uint8_t*) base) + size) || next_p <= p || next_p->next == 0 ) {
+             str->printf("WARNING: Pool metadata might be corrupted or inconsistent at block %p. Aborting debug walk.\n", p);
+             // Reset calculated values as they might be unreliable
+             total_used = 0;
+             total_fragmented_free = 0;
+             unallocated_at_end = 0;
+             break;
+        }
+        p = next_p;
+
     } while (1);
+
+    uint32_t total_free_calculated = total_fragmented_free + unallocated_at_end;
+
+    // Verify consistency check using the ->free() method which independently walks the list
+    uint32_t total_free_verified = this->free();
+    if (total_used + total_free_calculated != size && (total_used != 0 || total_fragmented_free != 0 || unallocated_at_end != 0)) {
+         str->printf("WARNING: Pool sizes calculated by debug walk don't add up! Used(%lu) + FragmentedFree(%lu) + Unallocated(%lu) != Size(%u)\n", total_used, total_fragmented_free, unallocated_at_end, size);
+         str->printf("         Using verified Total Free: %lu\n", total_free_verified);
+         // If inconsistent, trust the dedicated free() calculation unless it also mismatches
+         if (total_used + total_free_verified != size) {
+            str->printf("ERROR: Severe pool corruption suspected. Used + Verified Free != Size.\n");
+            // Keep calculated values but flag the severe error
+         } else {
+             // If verified free makes sense with used, adjust reported free components proportionally (or just report the verified total)
+             // For simplicity, just report the verified total free when inconsistent
+             total_fragmented_free = 0; // Mark as unknown due to inconsistency
+             unallocated_at_end = 0;    // Mark as unknown due to inconsistency
+             total_free_calculated = total_free_verified; // Trust the verified total
+         }
+    } else if (total_free_calculated != total_free_verified) {
+        // This case means (used + calculated_free == size) but (calculated_free != verified_free)
+        // This also indicates an inconsistency, likely in the debug walk logic vs free() logic.
+        str->printf("WARNING: Discrepancy between debug walk free count (%lu) and verified free count (%lu). Using verified count.\n", total_free_calculated, total_free_verified);
+        total_fragmented_free = 0; // Mark as unknown due to inconsistency
+        unallocated_at_end = 0;    // Mark as unknown due to inconsistency
+        total_free_calculated = total_free_verified; // Trust the verified total
+    }
+
+
+    str->printf("End: Pool Size %u, Used %lu, Fragmented Free %lu, Unallocated %lu, Total Free %lu\n",
+                size, total_used, total_fragmented_free, unallocated_at_end, total_free_calculated);
 }
 
 bool MemoryPool::has(void* p)
@@ -236,19 +329,33 @@ bool MemoryPool::has(void* p)
     return ((p >= base) && (p < (void*) (((uint8_t*) base) + size)));
 }
 
+// Calculates total free space by walking the list
 uint32_t MemoryPool::free()
 {
-    uint32_t free = 0;
-
+    uint32_t free_bytes = 0;
     _poolregion* p = (_poolregion*) base;
 
     do {
-        if (p->used == 0)
-            free += p->next;
-        if (offset(p) + p->next >= size)
-            return free;
-        if (p->next <= sizeof(_poolregion))
-            return free;
-        p = (_poolregion*) (((uint8_t*) p) + p->next);
+        if (p->used == 0) {
+            free_bytes += p->next; // Add the size of the free block
+        }
+
+        // Check for end condition or corruption before advancing p
+        if (offset(p) + p->next >= size || p->next <= sizeof(_poolregion)) {
+            break; // Reached end or invalid block size
+        }
+
+        _poolregion* next_p = (_poolregion*) (((uint8_t*) p) + p->next);
+        
+        // Safety check for corruption
+        if (next_p >= (_poolregion*) (((uint8_t*) base) + size) || next_p <= p || next_p->next == 0 ) {
+             // Log error if possible, but return calculated free so far
+             MDEBUG("Pool metadata corruption detected during free() calculation at block %p.\n", p);
+             break;
+        }
+        p = next_p;
+
     } while (1);
+
+    return free_bytes;
 }

--- a/src/libs/ahbmalloc.cpp
+++ b/src/libs/ahbmalloc.cpp
@@ -12,9 +12,7 @@ void* ahbmalloc(size_t size, BANK bank)
 	switch(bank)
 	{
 		case AHB_BANK_0:
-			return AHB0.alloc(size);
-		case AHB_BANK_1:
-			return AHB1.alloc(size);
+			return AHB.alloc(size);
 		default:
 			return NULL;
 	}

--- a/src/libs/ahbmalloc.h
+++ b/src/libs/ahbmalloc.h
@@ -10,7 +10,7 @@ typedef enum {
     AHB_NUM_BANKS
 } BANK;
 
-void* ahbmalloc(size_t size, BANK bank) __attribute__ ((warning("deprecated, please use new (AHB0) blah(); or blah = AHB0.alloc(size);")));
+void* ahbmalloc(size_t size, BANK bank) __attribute__ ((warning("deprecated, please use new (AHB) blah(); or blah = AHB.alloc(size);")));
 void ahbfree(void* ptr, size_t size);
 
 #endif /* _AHBMALLOC_H */

--- a/src/libs/platform_memory.cpp
+++ b/src/libs/platform_memory.cpp
@@ -1,4 +1,4 @@
 #include "platform_memory.h"
 
-MemoryPool* _AHB0;
-MemoryPool* _AHB1;
+MemoryPool* _ahb;
+

--- a/src/libs/platform_memory.h
+++ b/src/libs/platform_memory.h
@@ -3,10 +3,8 @@
 
 #include "MemoryPool.h"
 
-#define AHB0 (*_AHB0)
-#define AHB1 (*_AHB1)
+#define AHB (*_ahb)
 
-extern MemoryPool* _AHB0;
-extern MemoryPool* _AHB1;
+extern MemoryPool* _ahb;
 
 #endif /* _PLATFORM_MEMORY_H */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,23 +64,23 @@
 #define watchdog_timeout_checksum  CHECKSUM("watchdog_timeout")
 
 // USB Stuff
-//SDCard sd  __attribute__ ((section ("AHBSRAM0"))) (P0_18, P0_17, P0_15, P0_16);      // this selects SPI1 as the sdcard as it is on Smoothieboard
-SDFileSystem sd __attribute__ ((section ("AHBSRAM0"))) (P0_18, P0_17, P0_15, P0_16, 12000000);
+//SDCard sd  __attribute__ ((section ("AHBSRAM"))) (P0_18, P0_17, P0_15, P0_16);      // this selects SPI1 as the sdcard as it is on Smoothieboard
+SDFileSystem sd __attribute__ ((section ("AHBSRAM"))) (P0_18, P0_17, P0_15, P0_16, 12000000);
 //SDCard sd(P0_18, P0_17, P0_15, P0_16);  // this selects SPI0 as the sdcard
 //SDCard sd(P0_18, P0_17, P0_15, P2_8);  // this selects SPI0 as the sdcard witrh a different sd select
 
-// USB u __attribute__ ((section ("AHBSRAM0")));
-// USBSerial usbserial __attribute__ ((section ("AHBSRAM0"))) (&u);
+// USB u __attribute__ ((section ("AHBSRAM")));
+// USBSerial usbserial __attribute__ ((section ("AHBSRAM"))) (&u);
 
 /*
 #ifndef DISABLEMSD
-USBMSD msc __attribute__ ((section ("AHBSRAM0"))) (&u, &sd);
+USBMSD msc __attribute__ ((section ("AHBSRAM"))) (&u, &sd);
 #else
 USBMSD *msc= NULL;
 #endif
 */
 
-SDFAT mounter __attribute__ ((section ("AHBSRAM0"))) ("sd", &sd);
+SDFAT mounter __attribute__ ((section ("AHBSRAM"))) ("sd", &sd);
 
 GPIO leds[4] = {
     GPIO(P4_29),
@@ -140,7 +140,7 @@ void init() {
     if(sdok && !kernel->config->value( disable_msd_checksum )->by_default(true)->as_bool()){
         // HACK to zero the memory USBMSD uses as it and its objects seem to not initialize properly in the ctor
         size_t n= sizeof(USBMSD);
-        void *v = AHB0.alloc(n);
+        void *v = AHB.alloc(n);
         memset(v, 0, n); // clear the allocated memory
         msc= new(v) USBMSD(&u, &sd); // allocate object using zeroed memory
     }else{
@@ -151,21 +151,21 @@ void init() {
 #endif
 
     // Create and add main modules
-    kernel->add_module( new(AHB0) Player() );
+    kernel->add_module( new(AHB) Player() );
 
     // ATC Handler
-    kernel->add_module( new(AHB0) ATCHandler() );
+    kernel->add_module( new(AHB) ATCHandler() );
 
     // MSC File System Handler
-    kernel->add_module( new(AHB0) MSCFileSystem("ud") );
+    kernel->add_module( new(AHB) MSCFileSystem("ud") );
 
     // Serial Console 2
-    kernel->add_module( new(AHB0) SerialConsole2() );
+    kernel->add_module( new(AHB) SerialConsole2() );
 
-    kernel->add_module( new(AHB0) MainButton() );
+    kernel->add_module( new(AHB) MainButton() );
+
     // Wifi Provider
-    kernel->add_module( new(AHB0) WifiProvider() );
-
+    kernel->add_module( new(AHB) WifiProvider);
 
     // these modules can be completely disabled in the Makefile by adding to EXCLUDE_MODULES
     #ifndef NO_TOOLS_SWITCH
@@ -174,54 +174,54 @@ void init() {
     delete sp;
     #endif
 
-    #ifndef NO_TOOLS_EXTRUDER
-    // NOTE this must be done first before Temperature control so ToolManager can handle Tn before temperaturecontrol module does
-    ExtruderMaker *em= new(AHB0) ExtruderMaker();
-    em->load_tools();
-    delete em;
-    #endif
+    // #ifndef NO_TOOLS_EXTRUDER
+    // // NOTE this must be done first before Temperature control so ToolManager can handle Tn before temperaturecontrol module does
+    // ExtruderMaker *em= new(AHB) ExtruderMaker();
+    // em->load_tools();
+    // delete em;
+    // #endif
 
     // #ifndef NO_TOOLS_TEMPERATURECONTROL
     // Note order is important here must be after extruder so Tn as a parameter will get executed first
-    TemperatureControlPool *tp= new(AHB0) TemperatureControlPool();
+    TemperatureControlPool *tp= new(AHB) TemperatureControlPool();
     tp->load_tools();
     delete tp;
 
     // #endif
     #ifndef NO_TOOLS_ENDSTOPS
-    kernel->add_module( new(AHB0) Endstops() );
+    kernel->add_module( new(AHB) Endstops() );
     #endif
     #ifndef NO_TOOLS_LASER
-    kernel->add_module( new(AHB0) Laser() );
+    kernel->add_module( new(AHB) Laser() );
     #endif
 
     #ifndef NO_TOOLS_SPINDLE
-    SpindleMaker *sm = new(AHB0) SpindleMaker();
+    SpindleMaker *sm = new(AHB) SpindleMaker();
     sm->load_spindle();
     delete sm;
-    //kernel->add_module( new(AHB0) Spindle() );
+    //kernel->add_module( new(AHB) Spindle() );
     #endif
     #ifndef NO_UTILS_PANEL
-    // kernel->add_module( new(AHB0) Panel() );
+    // kernel->add_module( new(AHB) Panel() );
     #endif
     #ifndef NO_TOOLS_ZPROBE
-    kernel->add_module( new(AHB0) ZProbe() );
+    kernel->add_module( new(AHB) ZProbe() );
     #endif
     #ifndef NO_TOOLS_SCARACAL
-    kernel->add_module( new(AHB0) SCARAcal() );
+    kernel->add_module( new(AHB) SCARAcal() );
     #endif
     #ifndef NO_TOOLS_ROTARYDELTACALIBRATION
-    kernel->add_module( new(AHB0) RotaryDeltaCalibration() );
+    kernel->add_module( new(AHB) RotaryDeltaCalibration() );
     #endif
 //    #ifndef NONETWORK
 //    kernel->add_module( new Network() );
 //    #endif
     #ifndef NO_TOOLS_TEMPERATURESWITCH
     // Must be loaded after TemperatureControl
-    kernel->add_module( new(AHB0) TemperatureSwitch() );
+    kernel->add_module( new(AHB) TemperatureSwitch() );
     #endif
     #ifndef NO_TOOLS_DRILLINGCYCLES
-    kernel->add_module( new(AHB0) Drillingcycles() );
+    kernel->add_module( new(AHB) Drillingcycles() );
     #endif
     // Create and initialize USB stuff
     // u.init();
@@ -241,19 +241,22 @@ void init() {
     /* disable USB module
     kernel->add_module( &usbserial );
     if( kernel->config->value( second_usb_serial_enable_checksum )->by_default(false)->as_bool() ){
-        kernel->add_module( new(AHB0) USBSerial(&u) );
+        kernel->add_module( new(AHB) USBSerial(&u) );
     }
     */
 
     // if( kernel->config->value( dfu_enable_checksum )->by_default(false)->as_bool() ){
-    //     kernel->add_module( new(AHB0) DFU(&u));
+    //     kernel->add_module( new(AHB) DFU(&u));
     // }
 
     // 10 second watchdog timeout (or config as seconds)
+
+    // LUKE : DISABLED
+
     float t= kernel->config->value( watchdog_timeout_checksum )->by_default(10.0F)->as_number();
     if(t > 0.1F) {
         // NOTE setting WDT_RESET with the current bootloader would leave it in DFU mode which would be suboptimal
-        kernel->add_module( new(AHB0) Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
+        kernel->add_module( new(AHB) Watchdog(t * 1000000, WDT_RESET )); // WDT_RESET));
         kernel->streams->printf("Watchdog enabled for %1.3f seconds\n", t);
     }else{
         kernel->streams->printf("WARNING Watchdog is disabled\n");
@@ -291,7 +294,7 @@ void init() {
         }
     }
 
-    // start the timers and interrupts
+        // start the timers and interrupts
     THEKERNEL->conveyor->start(THEROBOT->get_number_registered_motors());
     THEKERNEL->step_ticker->start();
     THEKERNEL->slow_ticker->start();

--- a/src/modules/robot/Block.cpp
+++ b/src/modules/robot/Block.cpp
@@ -35,7 +35,6 @@ double Block::fp_scale= 0;
 
 Block::Block()
 {
-    tick_info= nullptr;
     line = 0;
     clear();
 }
@@ -86,14 +85,6 @@ void Block::clear()
     */
 
     total_move_ticks= 0;
-    if(tick_info == nullptr) {
-        // we create this once for this block
-        tick_info= new tickinfo_t[n_actuators]; //(tickinfo_t *)malloc(sizeof(tickinfo_t) * n_actuators);
-        if(tick_info == nullptr) {
-            // if we ran out of memory in AHB0 just stop here
-            __debugbreak();
-        }
-    }
 
     for(int i = 0; i < n_actuators; ++i) {
         tick_info[i].steps_per_tick= 0;

--- a/src/modules/robot/Block.h
+++ b/src/modules/robot/Block.h
@@ -66,7 +66,7 @@ class Block {
         };
 
         // need info for each active motor
-        tickinfo_t *tick_info;
+        std::array<tickinfo_t, k_max_actuators> tick_info;
 
         static uint8_t n_actuators;
 

--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -89,6 +89,11 @@
 #define clearance_y_checksum		CHECKSUM("clearance_y")
 #define clearance_z_checksum		CHECKSUM("clearance_z")
 
+// String message constants for common user prompts
+#define MSG_PROBE_COLLET_ANCHOR1 ";Confirm that a 3 axis probe is in collet\\nand anchor 1 is installed and clear\\nResume will continue program\\n"
+#define MSG_PROBE_COLLET_4AXIS ";Confirm that a 3 axis probe is in collet\\nand the 4th axis is installed and clear\\nResume will continue program\\n"
+#define MSG_TOOL_INSTALLED ";Tool is now installed.\\nRemove hands from the machine\\nResume will auto calibrate the tool and continue program\\n"
+
 ATCHandler::ATCHandler()
 {
     atc_status = NONE;
@@ -180,7 +185,6 @@ void ATCHandler::calibrate_set_value(Gcode *gcode)
 	} else{
 		float final_x = 0;
 		float final_y = 0;
-		float final_z = 0;
 		switch ((int)gcode->get_value('P')){
 			case 0:
 				//home off pin
@@ -253,7 +257,7 @@ void ATCHandler::calibrate_set_value(Gcode *gcode)
 void ATCHandler::calibrate_anchor1(Gcode *gcode) //M469.1
 {
 	THEKERNEL->streams->printf("Calibrating Anchor 1\n");
-	char buff[100];
+	char buff[115];
 	if (!THEROBOT->is_homed_all_axes()){
 		return;
 	}
@@ -267,7 +271,7 @@ void ATCHandler::calibrate_anchor1(Gcode *gcode) //M469.1
 	}
 
 	//print status
-	snprintf(buff, sizeof(buff), ";Confirm that a 3 axis probe is in collet\nand anchor 1 is installed and clear\nResume will continue program\n");
+	snprintf(buff, sizeof(buff), MSG_PROBE_COLLET_ANCHOR1);
 	this->script_queue.push(buff);
 	
 	//pause
@@ -370,7 +374,7 @@ void ATCHandler::calibrate_a_axis_headstock(Gcode *gcode)//M469.4
 	float probe_height= this->rotation_offset_z - 6;
 
 	THEKERNEL->streams->printf("Calibrating A Axis Headstock Center\n");
-	char buff[100];
+	char buff[115];
 	if (!THEROBOT->is_homed_all_axes()){
 		return;
 	}
@@ -383,14 +387,14 @@ void ATCHandler::calibrate_a_axis_headstock(Gcode *gcode)//M469.4
 		}
 	}
 	if (gcode->has_letter('Y')){
-		headstock_width = gcode->get_value('Y')/2+5;
+			headstock_width = gcode->get_value('Y')/2+5;
 	}
 	if (gcode->has_letter('E')){
 		probe_height = gcode->get_value('E');
 	}
 
 	//print status
-	snprintf(buff, sizeof(buff), ";Confirm that a 3 axis probe is in collet\nand the 4th axis is installed and clear\nResume will continue program\n");
+	snprintf(buff, sizeof(buff), MSG_PROBE_COLLET_4AXIS);
 	this->script_queue.push(buff);
 	
 	//pause
@@ -430,7 +434,6 @@ void ATCHandler::calibrate_a_axis_headstock(Gcode *gcode)//M469.4
 
 void ATCHandler::calibrate_a_axis_height(Gcode *gcode) //M469.5
 {
-	float probe_height= this->rotation_offset_z;
 	float x_axis_offset = 60;
 	float pin_diameter = 6;
 
@@ -451,7 +454,7 @@ void ATCHandler::calibrate_a_axis_height(Gcode *gcode) //M469.5
 		x_axis_offset = gcode->get_value('X');
 	}
 	if (gcode->has_letter('E')){
-		probe_height = gcode->get_value('E');
+		pin_diameter = gcode->get_value('E');
 	}
 	if (gcode->has_letter('R')){
 		pin_diameter = gcode->get_value('R');
@@ -614,7 +617,6 @@ void ATCHandler::fill_change_scripts(int new_tool, bool clear_z) {
 
 void ATCHandler::fill_manual_drop_scripts(int old_tool) {
 	char buff[100];
-	struct atc_tool *current_tool = &atc_tools[old_tool];
 	// set atc status
 	this->script_queue.push("M497.1");
 	//make extra sure the spindle is off
@@ -649,8 +651,7 @@ void ATCHandler::fill_manual_drop_scripts(int old_tool) {
 }
 
 void ATCHandler::fill_manual_pickup_scripts(int new_tool, bool clear_z, bool auto_calibrate = false, float custom_TLO = NAN) {
-	char buff[100];
-	struct atc_tool *current_tool = &atc_tools[new_tool];
+	char buff[115];
 	// set atc status
 	this->script_queue.push("M497.2");
 	// lift z to safe position with fast speed
@@ -676,7 +677,7 @@ void ATCHandler::fill_manual_pickup_scripts(int new_tool, bool clear_z, bool aut
 
 	if (auto_calibrate){
 		//print status
-		snprintf(buff, sizeof(buff), ";Tool is now installed.\nRemove hands from the machine\nResume will auto calibrate the tool and continue program\n");
+		snprintf(buff, sizeof(buff), MSG_TOOL_INSTALLED);
 		this->script_queue.push(buff);
 		//pause
 		snprintf(buff, sizeof(buff), "M600.5");

--- a/src/modules/tools/spindle/SoftSerial/SoftSerial_tx.cpp
+++ b/src/modules/tools/spindle/SoftSerial/SoftSerial_tx.cpp
@@ -60,8 +60,10 @@ void SoftSerial::prepare_tx(int c)
     switch (_parity) {
         case Forced1:
             _char |= 1 << (_bits + 1);
+            // fall through
         case Forced0:
             _char &= ~(1 << (_bits + 1));
+            // fall through
         case Even:
             parity = false;
             for (int i = 0; i<_bits; i++) {
@@ -69,6 +71,7 @@ void SoftSerial::prepare_tx(int c)
                     parity = !parity;
             }
             _char |= parity << (_bits + 1);
+            // fall through
         case Odd:
             parity = true;
             for (int i = 0; i<_bits; i++) {
@@ -76,6 +79,7 @@ void SoftSerial::prepare_tx(int c)
                     parity = !parity;
             }
             _char |= parity << (_bits + 1);
+            // fall through
         case None:
             // No parity, nothing to do here
             break;

--- a/src/modules/tools/temperaturecontrol/max31855.cpp
+++ b/src/modules/tools/temperaturecontrol/max31855.cpp
@@ -68,11 +68,16 @@ float Max31855::get_temperature()
     if(readings.size()==0) return infinityf();
 
     float sum = 0;
+    int count = 0;
     for (int i=0; i<readings.size(); i++) {
-        sum += *readings.get_ref(i);
+        float* ref = readings.get_ref(i);
+        if (ref) {
+            sum += *ref;
+            count++;
+        }
     }
-
-    return sum / readings.size();
+    if (count == 0) return infinityf();
+    return sum / count;
 }
 
 // ask the temperature sensor hardware for a value, store it in a buffer

--- a/src/modules/tools/zprobe/CartGridStrategy.cpp
+++ b/src/modules/tools/zprobe/CartGridStrategy.cpp
@@ -136,7 +136,7 @@ CartGridStrategy::CartGridStrategy(ZProbe *zprobe) : LevelingStrategy(zprobe)
 
 CartGridStrategy::~CartGridStrategy()
 {
-    if(grid != nullptr) AHB0.dealloc(grid);
+    if(grid != nullptr) AHB.dealloc(grid);
 }
 
 bool CartGridStrategy::handleConfig()
@@ -214,8 +214,8 @@ bool CartGridStrategy::handleConfig()
     std::replace(before_probe.begin(), before_probe.end(), '_', ' '); // replace _ with space
     std::replace(after_probe.begin(), after_probe.end(), '_', ' '); // replace _ with space
 
-    // allocate in AHB0
-    grid = (float *)AHB0.alloc(configured_grid_x_size * configured_grid_y_size * sizeof(float));
+    // allocate in AHB
+    grid = (float *)AHB.alloc(configured_grid_x_size * configured_grid_y_size * sizeof(float));
 
     if(grid == nullptr) {
         THEKERNEL->streams->printf("Error: Not enough memory\n");

--- a/src/modules/tools/zprobe/DeltaGridStrategy.cpp
+++ b/src/modules/tools/zprobe/DeltaGridStrategy.cpp
@@ -103,7 +103,7 @@ DeltaGridStrategy::DeltaGridStrategy(ZProbe *zprobe) : LevelingStrategy(zprobe)
 
 DeltaGridStrategy::~DeltaGridStrategy()
 {
-    if(grid != nullptr) AHB0.dealloc(grid);
+    if(grid != nullptr) AHB.dealloc(grid);
 }
 
 bool DeltaGridStrategy::handleConfig()
@@ -128,8 +128,8 @@ bool DeltaGridStrategy::handleConfig()
         }
     }
 
-    // allocate in AHB0
-    grid = (float *)AHB0.alloc(grid_size * grid_size * sizeof(float));
+    // allocate in AHB
+    grid = (float *)AHB.alloc(grid_size * grid_size * sizeof(float));
 
     if(grid == nullptr) {
         THEKERNEL->streams->printf("Error: Not enough memory\n");

--- a/src/modules/utils/player/Player.cpp
+++ b/src/modules/utils/player/Player.cpp
@@ -52,8 +52,8 @@
 
 extern SDFAT mounter;
 
-unsigned char xbuff[8200] __attribute__((section("AHBSRAM1"))); /* 2 for data length, 8192 for XModem + 3 head chars + 2 crc + nul */
-static unsigned char fbuff[4096] __attribute__((section("AHBSRAM1")));
+unsigned char xbuff[8200] __attribute__((section("AHBSRAM"))); /* 2 for data length, 8192 for XModem + 3 head chars + 2 crc + nul */
+static unsigned char fbuff[4096] __attribute__((section("AHBSRAM")));
 // used for XMODEM
 #define SOH  0x01
 #define STX  0x02

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -55,6 +55,7 @@
 #include "WifiPublicAccess.h"
 
 #include "mbed.h" // for wait_ms()
+#include <strings.h> // For strncasecmp
 
 extern unsigned int g_maximumHeapAddress;
 extern unsigned char xbuff[8200];
@@ -805,17 +806,21 @@ void SimpleShell::save_command( string parameters, StreamOutput *stream )
 void SimpleShell::mem_command( string parameters, StreamOutput *stream)
 {
     bool verbose = shift_parameter( parameters ).find_first_of("Vv") != string::npos;
-    unsigned long heap = (unsigned long)_sbrk(0);
-    unsigned long m = g_maximumHeapAddress - heap;
-    stream->printf("Unused Heap: %lu bytes\r\n", m);
+    unsigned long heap_top = (unsigned long)_sbrk(0);
+    unsigned long heap_unallocated_top = (STACK_SIZE && g_maximumHeapAddress != 0) ? g_maximumHeapAddress - heap_top : 0; // Calculate unallocated space at the top if stack limit is set
+    stream->printf("Main Heap Unallocated Top: %lu bytes\r\n", heap_unallocated_top);
 
-    uint32_t f = heapWalk(stream, verbose);
-    stream->printf("Total Free RAM: %lu bytes\r\n", m + f);
+    uint32_t heap_fragmented_free = heapWalk(stream, verbose); // Calculates and prints used/free within allocated heap part
+    stream->printf("Total Free RAM (Main Heap): %lu bytes\r\n", heap_unallocated_top + heap_fragmented_free);
 
-    stream->printf("Free AHB: %lu\r\n", AHB.free());
+    // Use MemoryPool::free() which calculates total free space in the pool
+    uint32_t ahb_total_free = AHB.free();
+    stream->printf("AHB Pool Total Free: %lu bytes\r\n", ahb_total_free);
 
     if (verbose) {
-        AHB.debug(stream);
+        stream->printf("--- AHB Pool Details ---\n");
+        AHB.debug(stream); // Detailed AHB pool breakdown
+        stream->printf("--- End AHB Pool Details ---\n");
     }
 
     stream->printf("Block size: %u bytes, Tickinfo size: %u bytes\n", sizeof(Block), sizeof(Block::tickinfo_t) * Block::n_actuators);

--- a/src/modules/utils/simpleshell/SimpleShell.cpp
+++ b/src/modules/utils/simpleshell/SimpleShell.cpp
@@ -812,10 +812,10 @@ void SimpleShell::mem_command( string parameters, StreamOutput *stream)
     uint32_t f = heapWalk(stream, verbose);
     stream->printf("Total Free RAM: %lu bytes\r\n", m + f);
 
-    stream->printf("Free AHB0: %lu, AHB1: %lu\r\n", AHB0.free(), AHB1.free());
+    stream->printf("Free AHB: %lu\r\n", AHB.free());
+
     if (verbose) {
-        AHB0.debug(stream);
-        AHB1.debug(stream);
+        AHB.debug(stream);
     }
 
     stream->printf("Block size: %u bytes, Tickinfo size: %u bytes\n", sizeof(Block), sizeof(Block::tickinfo_t) * Block::n_actuators);

--- a/src/modules/utils/wifi/M8266WIFIDrv.h
+++ b/src/modules/utils/wifi/M8266WIFIDrv.h
@@ -1347,7 +1347,6 @@ u8 M8266WIFI_SPI_Disconnect_TcpClient(u8 link_no, ClientInfo *client_info, u16* 
  *     =1, success                                                                 *
  *     =0, has error(s)                                                            *
  ***********************************************************************************/
- u8 M8266WIFI_SPI_Disconnect_TcpClient(u8 link_no, ClientInfo *client_info, u16* status);
 
 /***********************************************************************************
  * M8266WIFI_SPI_Query_Tcp_Retran_Max                                              *

--- a/src/modules/utils/wifi/WifiProvider.h
+++ b/src/modules/utils/wifi/WifiProvider.h
@@ -56,8 +56,8 @@ private:
     void query_wifi_status();
 
     uint32_t ip_to_int(char* ip_addr);
-    void int_to_ip(uint32_t i_ip, char *ip_addr);
-    void get_broadcast_from_ip_and_netmask(char *broadcast_addr, char *ip_addr, char *netmask);
+    void int_to_ip(uint32_t i_ip, char *ip_addr, size_t buffer_size);
+    void get_broadcast_from_ip_and_netmask(char *broadcast_addr, size_t broadcast_buffer_size, char *ip_addr, char *netmask);
 
     void on_pin_rise();
     void receive_wifi_data();
@@ -75,7 +75,7 @@ private:
 	int udp_recv_port;
 	int tcp_timeout_s;
 	int connection_fail_count;
-	string machine_name;
+	char machine_name[64]; // Fixed-size buffer to avoid std::string heap allocation
 	char ap_address[16];
 	char ap_netmask[16];
 	char sta_address[16];


### PR DESCRIPTION
* support GCC 10.3 toolchain, additional compiler flags conditionalized compiler
* merge AHB0 and AHB1 memory regions, much less wasted SRAM
* fixed edge cases in MemoryPool and report free memory correctly
* config flag to enable serial console to be taken over by GDB exclusively
* config flag to trigger breakpoint on machine halt
* added extensive documentation to the README and tidied it up in general 🙂
* fixed memory smasher in WifiProvider (seemed to only occur in very particular circumstances but GCC 10.3 exacerbated)
* optimizations in Block.cpp
* fixed a ton of compiler warnings
* turned on -fanalyze for null pointer warnings and fixed them

Memory stats after changes:

```
Main Heap Unallocated Top: 6036 bytes
Used Heap Size: 19548
Allocated: 7152, Free: 11372
Total Free RAM (Main Heap): 17408 bytes
AHB Pool Total Free: 984 bytes
Block size: 368 bytes, Tickinfo size: 280 bytes
```